### PR TITLE
ci(readme): update-recent 워크플로 푸시 실패 수정

### DIFF
--- a/.github/workflows/update-recent.yml
+++ b/.github/workflows/update-recent.yml
@@ -44,14 +44,19 @@ jobs:
           git add README.md
           git commit -m "chore(readme): auto-update recent solutions"
 
-          # 원격이 앞서있을 수 있으니 rebase 후 재시도 (최대 5회)
+          # 원격이 앞서있을 수 있으니 rebase 후 재시도 (최대 5회, jittered backoff)
           for i in 1 2 3 4 5; do
             if git push; then
               echo "Pushed on attempt $i."
               exit 0
             fi
             echo "Push rejected (attempt $i). Rebasing on latest origin/main and retrying..."
-            git pull --rebase --autostash origin main
+            if ! git pull --rebase --autostash origin main; then
+              echo "Rebase failed on attempt $i; aborting rebase." >&2
+              git rebase --abort || true
+              exit 1
+            fi
+            sleep $((RANDOM % 5 + i))
           done
           echo "Failed to push after 5 attempts." >&2
           exit 1

--- a/.github/workflows/update-recent.yml
+++ b/.github/workflows/update-recent.yml
@@ -7,6 +7,10 @@ on:
     - cron: "0 0 * * *"  # 매일 00:00 UTC (KST 09:00)
   workflow_dispatch:
 
+concurrency:
+  group: update-recent-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -33,10 +37,21 @@ jobs:
         run: |
           if git diff --quiet README.md; then
             echo "No README changes."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "chore(readme): auto-update recent solutions"
-            git push
+            exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore(readme): auto-update recent solutions"
+
+          # 원격이 앞서있을 수 있으니 rebase 후 재시도 (최대 5회)
+          for i in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed on attempt $i."
+              exit 0
+            fi
+            echo "Push rejected (attempt $i). Rebasing on latest origin/main and retrying..."
+            git pull --rebase --autostash origin main
+          done
+          echo "Failed to push after 5 attempts." >&2
+          exit 1


### PR DESCRIPTION
## 요약
- `update-recent.yml` 워크플로가 LeetHub/BaekjoonHub 봇 커밋과 경쟁하면서 `non-fast-forward`로 푸시가 거부되던 문제 수정
- `concurrency` 그룹 추가로 동일 브랜치 내 워크플로 직렬화 (`cancel-in-progress: false`)
- 푸시 실패 시 `git pull --rebase --autostash origin main` 후 최대 5회 재시도

## 배경
최근 실패 run: https://github.com/JeonJe/Algorithm/actions/runs/24704496976
```
! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs to 'https://github.com/JeonJe/Algorithm'
```

## 테스트 계획
- [ ] PR 머지 후 README 변경 유발 커밋을 푸시하여 워크플로 정상 완료 확인
- [ ] 봇 커밋과 거의 동시에 푸시되는 상황에서도 rebase 재시도로 성공하는지 관찰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 유지보수

* 자동 업데이트 워크플로우 개선: 동시 실행 제어를 추가하고 재시도 로직으로 푸시 안정성을 강화하여 자동화된 업데이트의 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->